### PR TITLE
Add support for opcode INST (i)

### DIFF
--- a/lib/jpickle.js
+++ b/lib/jpickle.js
@@ -54,7 +54,7 @@ Parser.prototype.load = function(pickle) {
       , APPENDS = 'e'           // extend list on stack by topmost stack slice
       , GET = 'g'               // push item from memo on stack; index is string arg
       , BINGET = 'h'            //   "    "    "    "   "   "  ;   "    " 1-byte arg
-      // missing INST
+      , INST = 'i'              // build a class instance
       , LONG_BINGET = 'j'       // push item from memo on stack; index is 4-byte arg
       , LIST = 'l'              // build list from topmost stack items
       , EMPTY_LIST = ']'        // push empty list
@@ -162,6 +162,23 @@ Parser.prototype.load = function(pickle) {
         case BINGET:
             var index = buffer.readUInt8(i++);
             this.stack.push(this.memo[''+index]);
+            break;
+        case INST:
+            var module = buffer.readLine(i);
+            i += module.length + 1;
+            var name = buffer.readLine(i);
+            i += name.length + 1;
+            var func = emulated[module + '.' + name];
+            if (func === undefined) {
+                throw "Cannot emulate global: " + module + " " + name;
+            }      
+            var obj = new func();
+            var mark = this.marker();
+            for (var pos = mark + 1; pos < this.stack.length; pos += 2) {
+                obj[this.stack[pos]] = this.stack[pos + 1];
+            }
+            this.stack = this.stack.slice(0, mark);
+            this.stack.push(obj);
             break;
         case LONG_BINGET:
             var index = buffer.readUInt32LE(i);


### PR DESCRIPTION
Add support for opcode INST (i)

Created from existing code for opcodes GLOBAL and OBJ and by looking at the [Python pickle.py source code](https://github.com/python/cpython/blob/2.7/Lib/pickle.py#L1072)